### PR TITLE
Add config declaration to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include README.md
 include LICENSE
+include requirements.txt
+include ckanext/fortify/config_declaration.yaml


### PR DESCRIPTION
Add config declaration to MANIFEST.in to be included if the extension is installed as a wheel 